### PR TITLE
Updated Nimbus to 2.10.0

### DIFF
--- a/com.adsbynimbus.nimbus/Editor/AndroidBuildDependencies.cs
+++ b/com.adsbynimbus.nimbus/Editor/AndroidBuildDependencies.cs
@@ -2,7 +2,7 @@ using System.Text;
 
 namespace Nimbus.Editor {
 	public static class AndroidBuildDependencies {
-		private const string SdkVersion = "2.1.0";
+		private const string SdkVersion = "2.8.0";
 
 		public static string BuildDependencies() {
 			var builder = new StringBuilder();

--- a/com.adsbynimbus.nimbus/Editor/AndroidPostBuildProcessor.cs
+++ b/com.adsbynimbus.nimbus/Editor/AndroidPostBuildProcessor.cs
@@ -30,8 +30,7 @@ allprojects {
 		private const string PackagingOptions = @"
 android {
 	packagingOptions {
-    	pickFirst ""META-INF/annotation-experimental_release.kotlin_module""
-		pickFirst ""META-INF/kotlin-stdlib.kotlin_module""
+    	pickFirst ""META-INF/*.kotlin_module""
 	}
 }";
 

--- a/com.adsbynimbus.nimbus/Editor/IOSBuildDependencies.cs
+++ b/com.adsbynimbus.nimbus/Editor/IOSBuildDependencies.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace Nimbus.Editor {
 	public class IOSBuildDependencies {
-		private const string SdkVersion = "2.1.0";
+		private const string SdkVersion = "2.8.1";
 		private readonly List<string> _dependencies = new List<string> {
 			"'NimbusKit'",
 			"'NimbusRenderVideoKit'",

--- a/com.adsbynimbus.nimbus/Runtime/Plugins/Android/UnityHelper.java
+++ b/com.adsbynimbus.nimbus/Runtime/Plugins/Android/UnityHelper.java
@@ -37,7 +37,7 @@ public final class UnityHelper {
             if (isBlocking) {
                 nimbusResponse.companionAds = new CompanionAd[]{activity.getResources().getConfiguration().orientation ==
                         Configuration.ORIENTATION_LANDSCAPE ?
-                        CompanionAd.end(480, 320) : CompanionAd.end(320, 480)};
+                        CompanionAd.Companion.end(480, 320) : CompanionAd.Companion.end(320, 480)};
                 
                 activity.runOnUiThread(() -> {
                     BlockingAdRenderer.setsCloseButtonDelayRender(closeButtonDelay * 1000);

--- a/com.adsbynimbus.nimbus/Runtime/Plugins/iOS/NimbusManager.swift
+++ b/com.adsbynimbus.nimbus/Runtime/Plugins/iOS/NimbusManager.swift
@@ -77,12 +77,7 @@ import NimbusRequestAPSKit
     }
     
     private func unityViewController() -> UIViewController? {
-        UIApplication.shared.connectedScenes
-            .filter { $0.activationState == .foregroundActive }
-            .compactMap { $0 as? UIWindowScene }
-            .first?.windows
-            .filter { $0.isKeyWindow }
-            .first?.rootViewController
+        UnityFramework.getInstance().appController().rootViewController
     }
     
     // MARK: - Public Functions


### PR DESCRIPTION
## Changes

- Update Nimbus iOS and Nimbus Android to 2.10.0
- Replaced use of iOS UIWindowScene with UnityFramework provided ViewController to fix an issue compiling against iOS 12
- Updated Android pickFirsts to fix transitive dependency issues with conflicting Kotlin versions
- Android init now explicitly defines each renderer to fix publisher build that was removing the service definition file required to auto init the SDK